### PR TITLE
Let users opt out of rehearsal calendar invite emails

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -290,6 +290,7 @@ class UsersController < ApiController
       phone_number
       preferred_name
       program_name
+      receive_rehearsal_calendar_invites
       state
       street_address
       timezone

--- a/app/services/publish_rehearsal_calendar.rb
+++ b/app/services/publish_rehearsal_calendar.rb
@@ -12,7 +12,7 @@ class PublishRehearsalCalendar
   private
 
   def publish_rehearsal(rehearsal)
-    current_ids = rehearsal.user_ids.to_set
+    current_ids = rehearsal.users.where(receive_rehearsal_calendar_invites: true).pluck(:id).to_set
     invited_ids = rehearsal.rehearsal_invites.pluck(:user_id).to_set
     # published_at tracks the exact `updated_at` value last published, not a wall-clock
     # timestamp — this is what makes "has this rehearsal changed since publish" a plain

--- a/db/migrate/20260714120000_add_receive_rehearsal_calendar_invites_to_users.rb
+++ b/db/migrate/20260714120000_add_receive_rehearsal_calendar_invites_to_users.rb
@@ -1,0 +1,5 @@
+class AddReceiveRehearsalCalendarInvitesToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :receive_rehearsal_calendar_invites, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_13_150000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_14_120000) do
   create_table "active_admin_comments", charset: "utf8mb3", force: :cascade do |t|
     t.string "namespace"
     t.text "body"
@@ -631,6 +631,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_13_150000) do
     t.string "headshot_url"
     t.boolean "paid_override", default: false, null: false
     t.string "resume_url"
+    t.boolean "receive_rehearsal_calendar_invites", default: true, null: false
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true, length: 255
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe 'Users API' do
     end
   end
 
+  describe 'PUT /api/v1/users/:id with receive_rehearsal_calendar_invites' do
+    before do
+      put "/api/v1/users/#{id}", params: { user: { receive_rehearsal_calendar_invites: false } }, as: :json, headers: authenticated_header(user)
+    end
+
+    it 'persists the preference' do
+      expect(user.reload.receive_rehearsal_calendar_invites).to eq(false)
+    end
+
+    it 'round-trips through the show endpoint' do
+      get "/api/v1/users/#{id}/", headers: authenticated_header(user)
+      expect(json['receive_rehearsal_calendar_invites']).to eq(false)
+    end
+  end
+
   describe 'access user data' do
     context 'when user is self' do
       before {

--- a/spec/services/publish_rehearsal_calendar_spec.rb
+++ b/spec/services/publish_rehearsal_calendar_spec.rb
@@ -126,6 +126,54 @@ RSpec.describe PublishRehearsalCalendar do
     end
   end
 
+  describe 'a user who has opted out of calendar invites, on the call list from the start' do
+    let(:opted_out_user) { create(:user, receive_rehearsal_calendar_invites: false) }
+    let!(:rehearsal) do
+      r = create(:rehearsal, production: production, start_time: 1.day.from_now, end_time: 1.day.from_now + 2.hours)
+      r.user_ids = [user1.id, opted_out_user.id]
+      r
+    end
+
+    it 'still invites the opted-in person' do
+      expect { run }.to have_enqueued_mail(RehearsalCalendarMailer, :invite).with(rehearsal.id, user1.id, 0)
+    end
+
+    it 'never invites the opted-out person' do
+      expect { run }.to have_enqueued_mail(RehearsalCalendarMailer, :invite).exactly(1).times
+    end
+
+    it 'does not create a rehearsal_invite row for the opted-out person' do
+      run
+      expect(rehearsal.rehearsal_invites.pluck(:user_id)).to contain_exactly(user1.id)
+    end
+  end
+
+  describe 'a user who opts out after already being invited' do
+    let!(:rehearsal) do
+      r = create(:rehearsal, production: production, start_time: 1.day.from_now, end_time: 1.day.from_now + 2.hours)
+      r.user_ids = [user1.id, user2.id]
+      r
+    end
+
+    before do
+      run
+      user2.update!(receive_rehearsal_calendar_invites: false)
+    end
+
+    it 'sends a cancellation to the person who opted out' do
+      expect { run }.to have_enqueued_mail(RehearsalCalendarMailer, :cancel).with(rehearsal.id, user2.id, 0)
+    end
+
+    it 'destroys their rehearsal_invite row' do
+      run
+      expect(rehearsal.rehearsal_invites.pluck(:user_id)).to contain_exactly(user1.id)
+    end
+
+    it 'does not resend to the still-opted-in person just because someone else changed' do
+      expect { run }.to have_enqueued_mail(RehearsalCalendarMailer, :invite).exactly(0).times
+    end
+  end
+
   describe 'a rehearsal in the past' do
     let!(:rehearsal) do
       r = create(:rehearsal, production: production, start_time: 1.day.ago, end_time: 1.day.ago + 2.hours)


### PR DESCRIPTION
## Summary
- Adds a `receive_rehearsal_calendar_invites` preference (boolean, default `true`) on `users`.
- `PublishRehearsalCalendar` now excludes opted-out users from a rehearsal's effective call list (single-line change at the `current_ids` computation). This means they're never newly invited, and if they already had a live invite from before opting out, it naturally falls into the existing call-list-removal path and gets cancelled on the next publish — no other service logic needed to change.
- `user_params` now permits `receive_rehearsal_calendar_invites` so users can set it on their own profile.

## Test plan
- [x] `bundle exec rspec spec/requests spec/models spec/services spec/mailers` — 981 examples, 0 failures
- [x] New specs cover: opted-out user never gets invited (others on the call list still do), and a user who opts out after already being invited gets a cancellation and their `rehearsal_invites` row cleaned up
- [ ] Manual: opt out, get added to a call list, have an admin publish — confirm no invite email arrives

Client PR: https://github.com/nilatti/henslowe-client-v2/pull/8 (must ship together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)