### PR TITLE
Allow production/theater admins to create conflicts for their users

### DIFF
--- a/app/controllers/api/v1/conflict_patterns_controller.rb
+++ b/app/controllers/api/v1/conflict_patterns_controller.rb
@@ -23,8 +23,10 @@ class ConflictPatternsController < ApiController
   # POST /conflicts
   # POST /conflicts.json
   def create
-    user_id = (conflict_pattern_params[:user_id] || params[:user_id])&.to_i
-    raise CanCan::AccessDenied unless user_id == current_user.id || current_user.superadmin?
+    target_user_id = (conflict_pattern_params[:user_id] || params[:user_id])&.to_i
+    target_user = target_user_id && User.find_by(id: target_user_id)
+    raise CanCan::AccessDenied unless current_user.can_manage_conflicts_for?(target_user)
+
     @conflict_pattern = ConflictPattern.new(conflict_pattern_params)
 
     if @conflict_pattern.save

--- a/app/controllers/api/v1/conflicts_controller.rb
+++ b/app/controllers/api/v1/conflicts_controller.rb
@@ -23,8 +23,10 @@ class ConflictsController < ApiController
   # POST /conflicts
   # POST /conflicts.json
   def create
-    user_id = (conflict_params[:user_id] || params[:user_id])&.to_i
-    raise CanCan::AccessDenied unless user_id == current_user.id || current_user.superadmin?
+    target_user_id = (conflict_params[:user_id] || params[:user_id])&.to_i
+    target_user = target_user_id && User.find_by(id: target_user_id)
+    raise CanCan::AccessDenied unless current_user.can_manage_conflicts_for?(target_user)
+
     @conflict = Conflict.new(conflict_params)
 
     if @conflict.save

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -205,7 +205,7 @@ class UsersController < ApiController
   def build_conflict_schedule
     puts "build conflict schedule called"
     set_user
-    authorize! :update, @user
+    raise CanCan::AccessDenied unless current_user.can_manage_conflicts_for?(@user)
     conflict_schedule_pattern = params[:conflict_schedule_pattern]
     end_date = conflict_schedule_pattern[:end_date] || Date.today + 1.year
     start_date = conflict_schedule_pattern[:start_date] || Date.today

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -51,14 +51,7 @@ class ApiController < ActionController::API
     end
   end
 
-  # Allow the user themselves, superadmins, and any production/theater admin
-  # who shares a production with the target user to read that user's conflicts.
   def can_view_user_conflicts?(target_user_id)
-    return true if current_user.id == target_user_id
-    return true if current_user.superadmin?
-
-    Production.joins(:jobs).where(jobs: { user_id: target_user_id }).distinct.any? do |production|
-      current_user.production_admin?(production) || current_user.theater_admin?(production.theater)
-    end
+    current_user.can_manage_conflicts_for?(User.find(target_user_id))
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,8 +19,12 @@ class Ability
       can :manage, :all
 
     elsif user.regular?
-      can :manage, Conflict, user_id: user.id
-      can :manage, ConflictPattern, user_id: user.id
+      can :manage, Conflict do |conflict|
+        user.can_manage_conflicts_for?(conflict.user)
+      end
+      can :manage, ConflictPattern do |conflict_pattern|
+        user.can_manage_conflicts_for?(conflict_pattern.user)
+      end
 
       can :manage, Theater do |theater|
         user.theater_admin?(theater)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,6 +207,18 @@ class User < ApplicationRecord
     self.jobs.select { |job| job.theater_id == theater.id }
   end
 
+  # Allow the user themselves, superadmins, and any production/theater admin
+  # who shares a production with the target user to manage that user's conflicts.
+  def can_manage_conflicts_for?(other_user)
+    return false if other_user.nil?
+    return true if id == other_user.id
+    return true if superadmin?
+
+    Production.joins(:jobs).where(jobs: { user_id: other_user.id }).distinct.any? do |production|
+      production_admin?(production) || theater_admin?(production.theater)
+    end
+  end
+
   def has_active_subscription?
     paid_override? || subscription_status == 'active'
   end

--- a/spec/requests/conflicts_spec.rb
+++ b/spec/requests/conflicts_spec.rb
@@ -133,4 +133,43 @@ RSpec.describe 'Conflicts API' do
       expect(response).to have_http_status(204)
     end
   end
+
+  describe 'POST /conflicts as a production admin acting on behalf of an actor' do
+    let!(:production) { create(:production) }
+    let!(:admin_user) { create(:user, :paid) }
+    let!(:actor) { create(:user) }
+
+    before do
+      create(:job, production: production, theater: production.theater, user: admin_user, specialization: create(:specialization, :director))
+      create(:job, production: production, theater: production.theater, user: actor, specialization: create(:specialization, :actor))
+    end
+
+    it 'allows creating a one-time conflict for the actor' do
+      post "/api/v1/users/#{actor.id}/conflicts",
+        params: { conflict: { user_id: actor.id, start_time: Time.now, end_time: Time.now + 1.hour } },
+        as: :json, headers: authenticated_header(admin_user)
+
+      expect(response).to have_http_status(201)
+      expect(Conflict.where(user_id: actor.id).count).to eq(1)
+    end
+
+    it 'allows creating a recurring conflict pattern for the actor' do
+      post "/api/v1/users/#{actor.id}/conflict_patterns",
+        params: { conflict_pattern: { user_id: actor.id, start_date: Date.today, end_date: Date.today + 30, start_time: "05:00", end_time: "09:00", category: "rehearsal" } },
+        as: :json, headers: authenticated_header(admin_user)
+
+      expect(response).to have_http_status(201)
+      expect(ConflictPattern.where(user_id: actor.id).count).to eq(1)
+    end
+
+    it 'denies creating a conflict for a user outside the admin\'s productions' do
+      outsider = create(:user)
+
+      post "/api/v1/users/#{outsider.id}/conflicts",
+        params: { conflict: { user_id: outsider.id, start_time: Time.now, end_time: Time.now + 1.hour } },
+        as: :json, headers: authenticated_header(admin_user)
+
+      expect(response).to have_http_status(403)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Fixes a 403 when a production or theater admin tries to create a one-time or recurring conflict for an actor/user in their production (or `build_conflict_schedule`) — the authorization checks only ever allowed self-service creation or superadmin, never admin-on-behalf-of-another-user.
- Adds `User#can_manage_conflicts_for?(other_user)` (self, superadmin, or production/theater admin sharing a production with that user) and uses it consistently in `Ability`, `ConflictsController#create`, `ConflictPatternsController#create`, and `UsersController#build_conflict_schedule`, replacing three drifted, hand-rolled/duplicated checks.
- Consolidated the existing read-path check (`can_view_user_conflicts?`) to delegate to the same method instead of maintaining a separate copy of the same logic.

## Test plan
- [x] Added request specs in `spec/requests/conflicts_spec.rb`: production admin creates a one-time conflict for an actor, creates a recurring conflict pattern for an actor, and is denied for a user outside their productions.
- [x] `bundle exec rspec spec/requests/conflicts_spec.rb` — 19 examples, 0 failures
- [x] `bundle exec rspec spec/requests/users_spec.rb spec/requests/authorization_spec.rb spec/models/user_spec.rb` — 161 examples, 0 failures
- [x] Full suite: `bundle exec rspec` — 984 examples, 0 failures

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>